### PR TITLE
You don't need a sort to find the top element

### DIFF
--- a/Spelling.hs
+++ b/Spelling.hs
@@ -2,10 +2,11 @@ module Spelling (TrainingDict, nWords, correct) where
 
 import qualified Data.ByteString.Char8            as B
 import           Data.Char                        (isAlpha, toLower)
-import           Data.List                        (foldl', sortBy)
+import           Data.List                        (foldl', maximumBy)
 import qualified Data.Map.Strict                  as M
 import           Data.Ord                         (comparing)
 import qualified Data.Set                         as S
+import           Data.Function                    (on)
 import           Paths_Norvigs_Spelling_Corrector (getDataFileName)
 
 type WordSet = S.Set String
@@ -56,11 +57,7 @@ choices w ws = foldr orNextIfEmpty (S.singleton w)
   where orNextIfEmpty x y = if S.null x then y else x
 
 chooseBest :: WordSet -> TrainingDict -> String
-chooseBest ch ws = chooseBest' $
-  ws `M.intersection` M.fromList (map (\x -> (x, ())) (S.toList ch))
-  where
-    chooseBest' bestChs = head (map fst (sortCandidates bestChs))
-    sortCandidates = sortBy (comparing snd) . M.toList
+chooseBest ch ws = maximumBy (compare `on` (\w -> M.findWithDefault 0 w ws)) (S.toList ch)
 
 correct :: TrainingDict -> String -> String
 correct ws w = chooseBest (choices w ws) ws


### PR DESCRIPTION
Trying this in ghci, 'compare' is already pulled in by prelude. This change is closer to Norvig's python implementation ("return max(candidates, key=NWORDS.get)")  but also removes a needless sort - if you just need the maximum, an O(n) single pass is all you need, not an O(n logn) sort.
